### PR TITLE
fixed version embedding

### DIFF
--- a/version.go
+++ b/version.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-//go:embed "version.txt"
+//go:embed ".version"
 var versionString string
 
 func Version() string {


### PR DESCRIPTION
version.go included version.txt which is ignored via .gitignore
now .version is included instead